### PR TITLE
Fix titles in VLC and duplicate paths

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/jamesnetherton/m3u"
 	"github.com/pierre-emmanuelJ/iptv-proxy/pkg/config"
 
 	"github.com/pierre-emmanuelJ/iptv-proxy/pkg/routes"
 
-	"github.com/jamesnetherton/m3u"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -23,7 +23,8 @@ var rootCmd = &cobra.Command{
 	Use:   "iptv-proxy",
 	Short: "A brief description of your application",
 	Run: func(cmd *cobra.Command, args []string) {
-		playlist, err := m3u.Parse(viper.GetString("m3u-url"))
+		m3uURL := viper.GetString("m3u-url")
+		playlist, err := m3u.Parse(m3uURL)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,8 @@
 package config
 
-import "github.com/jamesnetherton/m3u"
+import (
+	"github.com/jamesnetherton/m3u"
+)
 
 // HostConfiguration containt host infos
 type HostConfiguration struct {

--- a/pkg/m3u/m3u.go
+++ b/pkg/m3u/m3u.go
@@ -13,7 +13,7 @@ func Marshall(p *m3u.Playlist) (string, error) {
 	result := "#EXTM3U\n"
 	for _, track := range p.Tracks {
 		result += "#EXTINF:"
-		result += fmt.Sprintf("%d ", track.Length)
+		result += fmt.Sprintf("%d,", track.Length)
 		for i := range track.Tags {
 			if i == len(track.Tags)-1 {
 				result += fmt.Sprintf("%s=%q,", track.Tags[i].Name, track.Tags[i].Value)
@@ -30,17 +30,13 @@ func Marshall(p *m3u.Playlist) (string, error) {
 // ReplaceURL replace original playlist url by proxy url
 func ReplaceURL(proxyConfig *config.ProxyConfig) (*m3u.Playlist, error) {
 	result := make([]m3u.Track, 0, len(proxyConfig.Playlist.Tracks))
-	for _, track := range proxyConfig.Playlist.Tracks {
-		oriURL, err := url.Parse(track.URI)
-		if err != nil {
-			return nil, err
-		}
+	for i, track := range proxyConfig.Playlist.Tracks {
 		config := proxyConfig.HostConfig
 		uri := fmt.Sprintf(
-			"http://%s:%d%s?user=%s&password=%s",
+			"http://%s:%d/%d?user=%s&password=%s",
 			config.Hostname,
 			config.Port,
-			oriURL.RequestURI(),
+			i,
 			proxyConfig.User,
 			proxyConfig.Password,
 		)

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -102,6 +102,8 @@ func (p *proxy) reverseProxy(c *gin.Context) {
 		if resp.StatusCode == http.StatusForbidden && forbiddenRestart > 0 {
 			forbiddenRestart--
 			return true
+		} else if resp.StatusCode == http.StatusForbidden {
+			return false
 		}
 
 		copyHTTPHeader(c, resp.Header)

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -52,17 +52,15 @@ func Routes(proxyConfig *config.ProxyConfig, r *gin.RouterGroup, newM3U []byte) 
 	// XXX Private need for external Android app
 	r.POST("/iptv.m3u", p.authenticate, p.getM3U)
 
-	for i, track := range proxyConfig.Playlist.Tracks {
-		oriURL, err := url.Parse(track.URI)
-		if err != nil {
-			return
-		}
+	for i, _ := range proxyConfig.Playlist.Tracks {
 		tmp := &proxy{
 			nil,
 			&proxyConfig.Playlist.Tracks[i],
 			nil,
 		}
-		r.GET(oriURL.RequestURI(), p.authenticate, tmp.reverseProxy)
+
+		uri := fmt.Sprintf("/%d", i)
+		r.GET(uri, p.authenticate, tmp.reverseProxy)
 	}
 }
 

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/jamesnetherton/m3u"
 
@@ -65,6 +66,12 @@ func Routes(proxyConfig *config.ProxyConfig, r *gin.RouterGroup, newM3U []byte) 
 }
 
 func (p *proxy) reverseProxy(c *gin.Context) {
+
+	log.Printf("[iptv-proxy] %v | %s |Track\t%s\n",
+		time.Now().Format("2006/01/02 - 15:04:05"),
+		c.ClientIP(), p.Track.Name,
+	)
+
 	rpURL, err := url.Parse(p.Track.URI)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Here's the problematic part of the m3u I tried:

```
#EXTINF:0,43. Grosse Radio Metal
http://hd.lagrosseradio.info:8200/;stream.nsv
#EXTINF:0,44. Grosse Radio Rock
http://hd.lagrosseradio.info:8500/;stream.nsv
```

So instead I decided to just use the track index as the path, and it works.

Also, when opening the m3u in VLC, the titles were not displayed correctly, which is why I added the comma to the `Marshall` function.