### PR TITLE
WIP: Try to Improve stream restart on streaming cut

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/jamesnetherton/m3u"
 	"github.com/pierre-emmanuelJ/iptv-proxy/pkg/config"
 
 	"github.com/pierre-emmanuelJ/iptv-proxy/pkg/routes"
 
-	"github.com/jamesnetherton/m3u"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -23,7 +23,8 @@ var rootCmd = &cobra.Command{
 	Use:   "iptv-proxy",
 	Short: "A brief description of your application",
 	Run: func(cmd *cobra.Command, args []string) {
-		playlist, err := m3u.Parse(viper.GetString("m3u-url"))
+		m3uURL := viper.GetString("m3u-url")
+		playlist, err := m3u.Parse(m3uURL)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,8 @@
 package config
 
-import "github.com/jamesnetherton/m3u"
+import (
+	"github.com/jamesnetherton/m3u"
+)
 
 // HostConfiguration containt host infos
 type HostConfiguration struct {

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -102,6 +102,8 @@ func (p *proxy) reverseProxy(c *gin.Context) {
 		if resp.StatusCode == http.StatusForbidden && forbiddenRestart > 0 {
 			forbiddenRestart--
 			return true
+		} else if resp.StatusCode == http.StatusForbidden {
+			return false
 		}
 
 		copyHTTPHeader(c, resp.Header)

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/jamesnetherton/m3u"
 
@@ -65,6 +66,12 @@ func Routes(proxyConfig *config.ProxyConfig, r *gin.RouterGroup, newM3U []byte) 
 }
 
 func (p *proxy) reverseProxy(c *gin.Context) {
+
+	log.Printf("[iptv-proxy] %v | %s |Track\t%s\n",
+		time.Now().Format("2006/01/02 - 15:04:05"),
+		c.ClientIP(), p.Track.Name,
+	)
+
 	rpURL, err := url.Parse(p.Track.URI)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Restart the stream when the original provider return an http 200 ok because stream normally seams to be permanent (that prevent the final user video player cutting or restarting).

try  to restart 10 times on http 403

this is work but the issue is:
with some video player the video freeze and don't continue.