### PR TITLE
Fix m3u url path by escaping it

### DIFF
--- a/pkg/m3u/m3u.go
+++ b/pkg/m3u/m3u.go
@@ -13,7 +13,7 @@ func Marshall(p *m3u.Playlist) (string, error) {
 	result := "#EXTM3U\n"
 	for _, track := range p.Tracks {
 		result += "#EXTINF:"
-		result += fmt.Sprintf("%d ", track.Length)
+		result += fmt.Sprintf("%d, ", track.Length)
 		for i := range track.Tags {
 			if i == len(track.Tags)-1 {
 				result += fmt.Sprintf("%s=%q,", track.Tags[i].Name, track.Tags[i].Value)
@@ -46,9 +46,9 @@ func ReplaceURL(playlist *m3u.Playlist, user, password string, hostConfig *confi
 			protocol,
 			hostConfig.Hostname,
 			hostConfig.Port,
-			oriURL.Path,
-			user,
-			password,
+			oriURL.EscapedPath(),
+			url.QueryEscape(user),
+			url.QueryEscape(password),
 		)
 		destURL, err := url.Parse(uri)
 		if err != nil {

--- a/pkg/routes/xtream.go
+++ b/pkg/routes/xtream.go
@@ -298,9 +298,9 @@ func xtreamReplaceURL(playlist *m3u.Playlist, user, password string, hostConfig 
 			protocol,
 			hostConfig.Hostname,
 			hostConfig.Port,
-			user,
-			password,
-			id,
+			url.QueryEscape(user),
+			url.QueryEscape(password),
+			url.QueryEscape(id),
 		)
 		destURL, err := url.Parse(uri)
 		if err != nil {


### PR DESCRIPTION
This PR fix the urls path in the new m3u file 

Fix #16 
Fix #15 

This is a fix for these issues, but in the future all that part will be removed and refactored by this #17 