### PR TITLE
Add custom endpoint and custom m3u filename

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,8 @@ var rootCmd = &cobra.Command{
 			User:               viper.GetString("user"),
 			Password:           viper.GetString("password"),
 			HTTPS:              viper.GetBool("https"),
+			M3UFileName:        viper.GetString("m3u-file-name"),
+			CustomEndpoint:     viper.GetString("custom-endpoint"),
 		}
 
 		if e := routes.Serve(conf); e != nil {
@@ -99,6 +101,8 @@ func init() {
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "iptv-proxy-config", "C", "config file (default is $HOME/.iptv-proxy.yaml)")
 	rootCmd.Flags().StringP("m3u-url", "u", "", `iptv m3u file or url e.g: "http://example.com/iptv.m3u"`)
+	rootCmd.Flags().StringP("m3u-file-name", "", "iptv.m3u", `name of the new proxified m3u file e.g "http://poxy.com/iptv.m3u"`)
+	rootCmd.Flags().StringP("custom-endpoint", "", "", `custom endpoint "http://poxy.com/<custom-endpoint>/iptv.m3u"`)
 	rootCmd.Flags().Int64("port", 8080, "Port to expose the IPTVs endpoints")
 	rootCmd.Flags().String("hostname", "", "Hostname or IP to expose the IPTVs endpoints")
 	rootCmd.Flags().BoolP("https", "", false, "Activate https for urls proxy")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,8 @@ type ProxyConfig struct {
 	XtreamPassword     string
 	XtreamBaseURL      string
 	M3UCacheExpiration int
+	M3UFileName        string
+	CustomEndpoint     string
 	RemoteURL          *url.URL
 	HTTPS              bool
 	//XXX Very unsafe

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -46,6 +46,8 @@ func Routes(proxyConfig *config.ProxyConfig, r *gin.RouterGroup) {
 		nil,
 	}
 
+	r = r.Group(p.CustomEndpoint)
+
 	//Xtream service endopoints
 	if p.ProxyConfig.XtreamBaseURL != "" {
 		r.GET("/get.php", p.authenticate, p.xtreamGet)
@@ -63,17 +65,17 @@ func Routes(proxyConfig *config.ProxyConfig, r *gin.RouterGroup) {
 			p.XtreamUser == p.RemoteURL.Query().Get("username") &&
 			p.XtreamPassword == p.RemoteURL.Query().Get("password") {
 
-			r.GET("/iptv.m3u", p.authenticate, p.xtreamGetAuto)
-			// XXX Private need for external Android app
-			r.POST("/iptv.m3u", p.authenticate, p.xtreamGetAuto)
+			r.GET("/"+p.M3UFileName, p.authenticate, p.xtreamGetAuto)
+			// XXX Private need: for external Android app
+			r.POST("/"+p.M3UFileName, p.authenticate, p.xtreamGetAuto)
 
 			return
 		}
 	}
 
-	r.GET("/iptv.m3u", p.authenticate, p.getM3U)
-	// XXX Private need for external Android app
-	r.POST("/iptv.m3u", p.authenticate, p.getM3U)
+	r.GET("/"+p.M3UFileName, p.authenticate, p.getM3U)
+	// XXX Private need: for external Android app
+	r.POST("/"+p.M3UFileName, p.authenticate, p.getM3U)
 
 	newM3U := []byte{}
 	var err error
@@ -109,7 +111,7 @@ func Routes(proxyConfig *config.ProxyConfig, r *gin.RouterGroup) {
 }
 
 func (p *proxy) getM3U(c *gin.Context) {
-	c.Header("Content-Disposition", "attachment; filename=\"iptv.m3u\"")
+	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename=%q`, p.M3UFileName))
 	c.Data(http.StatusOK, "application/octet-stream", p.newM3U)
 }
 

--- a/pkg/routes/xtream.go
+++ b/pkg/routes/xtream.go
@@ -122,7 +122,7 @@ func (p *proxy) xtreamGet(c *gin.Context) {
 		xtreamM3uCacheLock.RUnlock()
 	}
 
-	c.Header("Content-Disposition", "attachment; filename=\"iptv.m3u\"")
+	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename=%q`, p.M3UFileName))
 	xtreamM3uCacheLock.RLock()
 	path := xtreamM3uCache[m3uURL.String()].string
 	xtreamM3uCacheLock.RUnlock()


### PR DESCRIPTION
Add custom new proxified m3u file name with  flag `--m3u-file-name` by default at `iptv.m3u`
example:
`--m3u-file-name new.m3u` > `http://proxy.com/new.m3u`

Add custom endpoint with flag `--custom-endpoint "custom-endpoint"` >  `http://proxy.com/custom-endpoint/new.m3u`


Fix #20 