### PR TITLE
Add m3u group filtering

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,11 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
+		filters := map[string](bool){}
+		for _, groupName := range viper.GetStringSlice("filter-groups") {
+			filters[groupName] = true
+		}
+
 		conf := &config.ProxyConfig{
 			HostConfig: &config.HostConfiguration{
 				Hostname: viper.GetString("hostname"),
@@ -83,6 +88,7 @@ var rootCmd = &cobra.Command{
 			HTTPS:              viper.GetBool("https"),
 			M3UFileName:        viper.GetString("m3u-file-name"),
 			CustomEndpoint:     viper.GetString("custom-endpoint"),
+			FilterGroups:       filters,
 		}
 
 		server, err := server.NewServer(conf)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,4 +53,5 @@ type ProxyConfig struct {
 	RemoteURL          *url.URL
 	HTTPS              bool
 	User, Password     CredentialString
+	FilterGroups       map[string](bool)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -96,9 +96,24 @@ func (c *Config) playlistInitialization() error {
 // MarshallInto a *bufio.Writer a Playlist.
 func (c *Config) marshallInto(into *os.File, xtream bool) error {
 	into.WriteString("#EXTM3U\n") // nolint: errcheck
+
+TRACKS_LOOP:
 	for _, track := range c.playlist.Tracks {
+
+		// Groups filtering
+		if len(c.FilterGroups) > 0 {
+			for i := range track.Tags {
+				name := track.Tags[i].Name
+				value := track.Tags[i].Value
+				if name == "group-title" && !c.FilterGroups[value] {
+					continue TRACKS_LOOP
+				}
+			}
+		}
+
 		into.WriteString("#EXTINF:")                       // nolint: errcheck
 		into.WriteString(fmt.Sprintf("%d ", track.Length)) // nolint: errcheck
+
 		for i := range track.Tags {
 			if i == len(track.Tags)-1 {
 				into.WriteString(fmt.Sprintf("%s=%q", track.Tags[i].Name, track.Tags[i].Value)) // nolint: errcheck


### PR DESCRIPTION
This PR allow filter m3u tracks (keep) based on `group-title` tag.

within iptv-proxy config file add:

```yaml
...
filter-groups:
  - "Group - The Shade Palace"
  - "Group - The Tornado Supreme"
  - "Group - The Brass"
  - "Group - The Servant"
  - "Group - The Monster Tower"
  - "Group - The Bizarre Boat"
  - "Group - Depth of Ecstasy"
  - "Group - Rider of Insanity"
  - "Group - Place of Whispers"
  - "Group - Tumble of Impulses"
```

I'm a beginner in golang so feel free to make any comments.


