### PR TITLE
Regex filters for channel names and groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,10 @@ Or
       XTREAM_PASSWORD: xtream_password
       XTREAM_BASE_URL: "http://example.com:1234"
       USER: test
-      PASSWORD: testpassword
+      PASSWORD: testpassword 
+      # REGEX filters
+      GROUP_REGEX: 'SPORTS|NEWS'
+      CHANNEL_REGEX: 'HD'
 ```
 
 ### Start

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,6 +83,8 @@ var rootCmd = &cobra.Command{
 			HTTPS:              viper.GetBool("https"),
 			M3UFileName:        viper.GetString("m3u-file-name"),
 			CustomEndpoint:     viper.GetString("custom-endpoint"),
+			GroupRegex:         viper.GetString("group-regex"),
+			ChannelRegex:       viper.GetString("channel-regex"),
 		}
 
 		server, err := server.NewServer(conf)
@@ -124,6 +126,8 @@ func init() {
 	rootCmd.Flags().String("xtream-password", "", "Xtream-code password login")
 	rootCmd.Flags().String("xtream-base-url", "", "Xtream-code base url e.g(http://expample.tv:8080)")
 	rootCmd.Flags().Int("m3u-cache-expiration", 1, "M3U cache expiration in hour")
+	rootCmd.Flags().String("group-regex", "", "Regex applied to groups for filtering")
+	rootCmd.Flags().String("channel-regex", "", "Regex applied to channel names for filtering")
 
 	if e := viper.BindPFlags(rootCmd.Flags()); e != nil {
 		log.Fatal("error binding PFlags to viper")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,4 +30,6 @@ services:
       #will be used for m3u and xtream auth poxy
       USER: test
       PASSWORD: testpassword
-
+      # REGEX filters
+      GROUP_REGEX: 'SPORTS|NEWS'
+      CHANNEL_REGEX: 'HD'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,4 +53,6 @@ type ProxyConfig struct {
 	RemoteURL          *url.URL
 	HTTPS              bool
 	User, Password     CredentialString
+	GroupRegex         string
+	ChannelRegex       string
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,3 +1,4 @@
+
 /*
  * Iptv-Proxy is a project to proxyfie an m3u file and to proxyfie an Xtream iptv service (client API).
  * Copyright (C) 2020  Pierre-Emmanuel Jacquier
@@ -23,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"regexp"
 
 	"github.com/jamesnetherton/m3u"
 	"github.com/pierre-emmanuelJ/iptv-proxy/pkg/config"
@@ -96,9 +98,34 @@ func (c *Config) playlistInitialization() error {
 // MarshallInto a *bufio.Writer a Playlist.
 func (c *Config) marshallInto(into *os.File, xtream bool) error {
 	into.WriteString("#EXTM3U\n") // nolint: errcheck
+
+	re_group := regexp.MustCompile(c.GroupRegex)
+	re_channel := regexp.MustCompile(c.ChannelRegex)
+
+TRACKS_LOOP:
 	for _, track := range c.playlist.Tracks {
+
+		// Group regex
+		if c.GroupRegex != "" {
+			for i := range track.Tags {
+				name := track.Tags[i].Name
+				value := track.Tags[i].Value
+				if name == "group-title" && !re_group.MatchString(value) {
+					continue TRACKS_LOOP
+				}
+			}
+		}
+
+		// Channel regex
+		if c.ChannelRegex != "" {
+			if !re_channel.MatchString(track.Name) {
+				continue TRACKS_LOOP
+			}
+		}
+
 		into.WriteString("#EXTINF:")                       // nolint: errcheck
 		into.WriteString(fmt.Sprintf("%d ", track.Length)) // nolint: errcheck
+
 		for i := range track.Tags {
 			if i == len(track.Tags)-1 {
 				into.WriteString(fmt.Sprintf("%s=%q", track.Tags[i].Name, track.Tags[i].Value)) // nolint: errcheck


### PR DESCRIPTION
- Added regex filtering to choose only some groups of the M3U playlist (Example: only SPORTS and NEWS groups)
- Added regex filtering to choose only some channels (Example: only those including HD in the name)

docker-compose.yml: 
```Yaml
 environment:
      GROUP_REGEX: 'SPORTS|NEWS'
      CHANNEL_REGEX: 'HD'
```

(Inspired on #57)