### PR TITLE
Add timeshift support

### DIFF
--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -56,6 +56,7 @@ func (c *Config) xtreamRoutes(r *gin.RouterGroup) {
 	r.GET("/xmltv.php", c.authenticate, c.xtreamXMLTV)
 	r.GET(fmt.Sprintf("/%s/%s/:id", c.User, c.Password), c.xtreamStream)
 	r.GET(fmt.Sprintf("/live/%s/%s/:id", c.User, c.Password), c.xtreamStreamLive)
+	r.GET(fmt.Sprintf("/timeshift/%s/%s/:duration/:start/:id", c.User, c.Password), c.xtreamStreamTimeshift)
 	r.GET(fmt.Sprintf("/movie/%s/%s/:id", c.User, c.Password), c.xtreamStreamMovie)
 	r.GET(fmt.Sprintf("/series/%s/%s/:id", c.User, c.Password), c.xtreamStreamSeries)
 	r.GET(fmt.Sprintf("/hlsr/:token/%s/%s/:channel/:hash/:chunk", c.User, c.Password), c.hlsrStream)

--- a/pkg/server/xtreamHandles.go
+++ b/pkg/server/xtreamHandles.go
@@ -220,6 +220,19 @@ func (c *Config) xtreamStreamLive(ctx *gin.Context) {
 	c.stream(ctx, rpURL)
 }
 
+func (c *Config) xtreamStreamTimeshift(ctx *gin.Context) {
+	duration := ctx.Param("duration")
+	start := ctx.Param("start")
+	id := ctx.Param("id")
+	rpURL, err := url.Parse(fmt.Sprintf("%s/timeshift/%s/%s/%s/%s/%s", c.XtreamBaseURL, c.XtreamUser, c.XtreamPassword, duration, start, id))
+	if err != nil {
+		ctx.AbortWithError(http.StatusInternalServerError, err) // nolint: errcheck
+		return
+	}
+
+	c.stream(ctx, rpURL)
+}
+
 func (c *Config) xtreamStreamMovie(ctx *gin.Context) {
 	id := ctx.Param("id")
 	rpURL, err := url.Parse(fmt.Sprintf("%s/movie/%s/%s/%s", c.XtreamBaseURL, c.XtreamUser, c.XtreamPassword, id))


### PR DESCRIPTION
Add support for timeshift (reverse EPG).
Not supported by Tivimate internal player, just like VOD content.
