### PR TITLE
Xtream-API: Add /play url support

### DIFF
--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -65,6 +65,7 @@ func (c *Config) xtreamRoutes(r *gin.RouterGroup) {
 	r.GET(fmt.Sprintf("/series/%s/%s/:id", c.User, c.Password), c.xtreamStreamSeries)
 	r.GET(fmt.Sprintf("/hlsr/:token/%s/%s/:channel/:hash/:chunk", c.User, c.Password), c.xtreamHlsrStream)
 	r.GET("/hls/:token/:chunk", c.xtreamHlsStream)
+	r.GET("/play/:token/:type", c.xtreamStreamPlay)
 }
 
 func (c *Config) m3uRoutes(r *gin.RouterGroup) {

--- a/pkg/server/xtreamHandles.go
+++ b/pkg/server/xtreamHandles.go
@@ -312,6 +312,18 @@ func (c *Config) xtreamStreamLive(ctx *gin.Context) {
 	c.xtreamStream(ctx, rpURL)
 }
 
+func (c *Config) xtreamStreamPlay(ctx *gin.Context) {
+	hash := ctx.Param("hash")
+	t := ctx.Param("type")
+	rpURL, err := url.Parse(fmt.Sprintf("%s/play/%s/%s", c.XtreamBaseURL, hash, t))
+	if err != nil {
+		ctx.AbortWithError(http.StatusInternalServerError, err) // nolint: errcheck
+		return
+	}
+
+	c.xtreamStream(ctx, rpURL)
+}
+
 func (c *Config) xtreamStreamTimeshift(ctx *gin.Context) {
 	duration := ctx.Param("duration")
 	start := ctx.Param("start")


### PR DESCRIPTION
Add the support of xtream api `/play/token/type` stream type

Since there is no more official xtream-api and documentation, this kind of hacky change will be more frequent...
This fix some IPTV providers.

Fix #83 

Credits: @tefinger