### PR TITLE
Skip over that line instead of returning error

### DIFF
--- a/vendor/github.com/jamesnetherton/m3u/m3u.go
+++ b/vendor/github.com/jamesnetherton/m3u/m3u.go
@@ -71,8 +71,9 @@ func Parse(fileName string) (Playlist, error) {
 			line := strings.Replace(line, "#EXTINF:", "", -1)
 			trackInfo := strings.Split(line, ",")
 			if len(trackInfo) < 2 {
-				return Playlist{},
-					errors.New("invalid m3u file format. Expected EXTINF metadata to contain track length and name data")
+				//return Playlist{},
+				//	errors.New("invalid m3u file format. Expected EXTINF metadata to contain track length and name data")
+				continue
 			}
 			length, parseErr := strconv.Atoi(strings.Split(trackInfo[0], " ")[0])
 			if parseErr != nil {


### PR DESCRIPTION
This reads line by line but fails the entire playlist file if one line is invalid. It's better to skip over it rather than deeming entire file useless. 
For my iptv provider it was broken and returning "Error #01: invalid m3u file format. Expected EXTINF metadata to contain track length and name data" because one of their tracks was missing a name which makes m3u parser not work. 