### PR TITLE
Adding argument to set custom anti-collision ID

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,7 @@ var rootCmd = &cobra.Command{
 			HTTPS:                viper.GetBool("https"),
 			M3UFileName:          viper.GetString("m3u-file-name"),
 			CustomEndpoint:       viper.GetString("custom-endpoint"),
+			CustomId:             viper.GetString("custom-id"),
 			XtreamGenerateApiGet: viper.GetBool("xtream-api-get"),
 		}
 
@@ -121,6 +122,7 @@ func init() {
 	rootCmd.Flags().StringP("m3u-url", "u", "", `Iptv m3u file or url e.g: "http://example.com/iptv.m3u"`)
 	rootCmd.Flags().StringP("m3u-file-name", "", "iptv.m3u", `Name of the new proxified m3u file e.g "http://poxy.com/iptv.m3u"`)
 	rootCmd.Flags().StringP("custom-endpoint", "", "", `Custom endpoint "http://poxy.com/<custom-endpoint>/iptv.m3u"`)
+	rootCmd.Flags().StringP("custom-id", "", "", `Custom anti-collison ID for each track "http://proxy.com/<custom-id>/..."`)
 	rootCmd.Flags().Int("port", 8080, "Iptv-proxy listening port")
 	rootCmd.Flags().Int("advertised-port", 0, "Port to expose the IPTV file and xtream (by default, it's taking value from port) useful to put behind a reverse proxy")
 	rootCmd.Flags().String("hostname", "", "Hostname or IP to expose the IPTVs endpoints")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,6 +51,7 @@ type ProxyConfig struct {
 	M3UCacheExpiration   int
 	M3UFileName          string
 	CustomEndpoint       string
+	CustomId             string
 	RemoteURL            *url.URL
 	AdvertisedPort       int
 	HTTPS                bool

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -64,6 +64,10 @@ func NewServer(config *config.ProxyConfig) (*Config, error) {
 		}
 	}
 
+        if trimmedCustomId := strings.Trim(config.CustomId, "/"); trimmedCustomId != "" {
+                endpointAntiColision = trimmedCustomId
+        }
+
 	return &Config{
 		config,
 		&p,


### PR DESCRIPTION
This enables the ability to provide a custom anti-collision ID, instead of using a randomly-generated UUID.  This is useful for preserving a specific track URL after a restart.