### PR TITLE
Fix XMLTV proxy routing issue and Xtream Codes VOD data handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ iptv/iptv.m3u
 # Backup files
 *.bak
 
+/.history
+/.lh
+

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@
 iptv-proxy
 iptv/iptv.m3u
 
+# Backup files
+*.bak
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 [![Actions Status](https://github.com/pierre-emmanuelJ/iptv-proxy/workflows/CI/badge.svg)](https://github.com/pierre-emmanuelJ/iptv-proxy/actions?query=workflow%3ACI)
 
+NOTE: This fork of the [original project](https://github.com/pierre-emmanuelJ/iptv-proxy) contains the following enhancements:
+
+- Corrected issue with Xtream Codes EPG not loading
+- Fixed issue with Xtream Codes VOD (Shows & Movies) as the IPTV provider returned data seems to be partially complete, or missing pieces that this proxy is expecting
+
+
+
 ## Description
 
 Iptv-Proxy is a project to proxyfie an m3u file

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,9 @@ var rootCmd = &cobra.Command{
 	Use:   "iptv-proxy",
 	Short: "Reverse proxy on iptv m3u file and xtream codes server api",
 	Run: func(cmd *cobra.Command, args []string) {
+
+		log.Printf("[iptv-proxy] Server is starting...")
+
 		m3uURL := viper.GetString("m3u-url")
 		remoteHostURL, err := url.Parse(m3uURL)
 		if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -64,9 +64,9 @@ func NewServer(config *config.ProxyConfig) (*Config, error) {
 		}
 	}
 
-        if trimmedCustomId := strings.Trim(config.CustomId, "/"); trimmedCustomId != "" {
-                endpointAntiColision = trimmedCustomId
-        }
+	if trimmedCustomId := strings.Trim(config.CustomId, "/"); trimmedCustomId != "" {
+		endpointAntiColision = trimmedCustomId
+	}
 
 	return &Config{
 		config,
@@ -87,6 +87,9 @@ func (c *Config) Serve() error {
 	router.Use(cors.Default())
 	group := router.Group("/")
 	c.routes(group)
+
+	// Add a message to indicate the server is ready
+	log.Printf("[iptv-proxy] Server is ready and listening on :%d", c.HostConfig.Port)
 
 	return router.Run(fmt.Sprintf(":%d", c.HostConfig.Port))
 }

--- a/vendor/github.com/tellytv/go.xtream-codes/structs.go
+++ b/vendor/github.com/tellytv/go.xtream-codes/structs.go
@@ -13,26 +13,26 @@ import (
 
 // ServerInfo describes the state of the Xtream-Codes server.
 type ServerInfo struct {
-	HTTPSPort    FlexInt   `json:"https_port,string"`
-	Port         FlexInt   `json:"port,string"`
+	HTTPSPort    FlexInt   `json:"https_port"`
+	Port         FlexInt   `json:"port"`
 	Process      bool      `json:"process"`
-	RTMPPort     FlexInt   `json:"rtmp_port,string"`
+	RTMPPort     FlexInt   `json:"rtmp_port"`
 	Protocol     string    `json:"server_protocol"`
 	TimeNow      string    `json:"time_now"`
-	TimestampNow Timestamp `json:"timestamp_now,string"`
+	TimestampNow Timestamp `json:"timestamp_now"`
 	Timezone     string    `json:"timezone"`
 	URL          string    `json:"url"`
 }
 
 // UserInfo is the current state of the user as it relates to the Xtream-Codes server.
 type UserInfo struct {
-	ActiveConnections    FlexInt            `json:"active_cons,string"`
+	ActiveConnections    FlexInt            `json:"active_cons"`
 	AllowedOutputFormats []string           `json:"allowed_output_formats"`
 	Auth                 ConvertibleBoolean `json:"auth"`
 	CreatedAt            Timestamp          `json:"created_at"`
 	ExpDate              *Timestamp         `json:"exp_date"`
-	IsTrial              ConvertibleBoolean `json:"is_trial,string"`
-	MaxConnections       FlexInt            `json:"max_connections,string"`
+	IsTrial              ConvertibleBoolean `json:"is_trial"`
+	MaxConnections       FlexInt            `json:"max_connections"`
 	Message              string             `json:"message"`
 	Password             string             `json:"password"`
 	Status               string             `json:"status"`
@@ -47,7 +47,7 @@ type AuthenticationResponse struct {
 
 // Category describes a grouping of Stream.
 type Category struct {
-	ID     FlexInt `json:"category_id,string"`
+	ID     FlexInt `json:"category_id"`
 	Name   string  `json:"category_name"`
 	Parent FlexInt `json:"parent_id"`
 
@@ -58,7 +58,7 @@ type Category struct {
 // Stream is a streamble video source.
 type Stream struct {
 	Added              *Timestamp `json:"added"`
-	CategoryID         FlexInt    `json:"category_id,string"`
+	CategoryID         FlexInt    `json:"category_id"`
 	CategoryName       string     `json:"category_name"`
 	ContainerExtension string     `json:"container_extension"`
 	CustomSid          string     `json:"custom_sid"`
@@ -79,7 +79,7 @@ type Stream struct {
 type SeriesInfo struct {
 	BackdropPath   *JSONStringSlice `json:"backdrop_path,omitempty"`
 	Cast           string           `json:"cast"`
-	CategoryID     *FlexInt         `json:"category_id,string"`
+	CategoryID     *FlexInt         `json:"category_id"`
 	Cover          string           `json:"cover"`
 	Director       string           `json:"director"`
 	EpisodeRunTime string           `json:"episode_run_time"`
@@ -88,7 +88,7 @@ type SeriesInfo struct {
 	Name           string           `json:"name"`
 	Num            FlexInt          `json:"num"`
 	Plot           string           `json:"plot"`
-	Rating         FlexInt          `json:"rating,string"`
+	Rating         FlexInt          `json:"rating"`
 	Rating5        FlexFloat        `json:"rating_5based"`
 	ReleaseDate    string           `json:"releaseDate"`
 	SeriesID       FlexInt          `json:"series_id"`
@@ -119,7 +119,7 @@ type VideoOnDemandInfo struct {
 	Info      *VODInfo `json:"info,omitempty"`
 	MovieData struct {
 		Added              Timestamp `json:"added"`
-		CategoryID         FlexInt   `json:"category_id,string"`
+		CategoryID         FlexInt   `json:"category_id"`
 		ContainerExtension string    `json:"container_extension"`
 		CustomSid          string    `json:"custom_sid"`
 		DirectSource       string    `json:"direct_source"`
@@ -155,9 +155,9 @@ type EPGInfo struct {
 	ChannelID      string             `json:"channel_id"`
 	Description    Base64Value        `json:"description"`
 	End            string             `json:"end"`
-	EPGID          FlexInt            `json:"epg_id,string"`
+	EPGID          FlexInt            `json:"epg_id"`
 	HasArchive     ConvertibleBoolean `json:"has_archive"`
-	ID             FlexInt            `json:"id,string"`
+	ID             FlexInt            `json:"id"`
 	Lang           string             `json:"lang"`
 	NowPlaying     ConvertibleBoolean `json:"now_playing"`
 	Start          string             `json:"start"`
@@ -354,6 +354,267 @@ func (ei *EpisodeInfo) UnmarshalJSON(data []byte) error {
 
 	// Log initial error and data only if subsequent unmarshalling fails
 	if logInitialError && initialErr != nil {
+		log.Println(errMsg)
+		log.Println(dataMsg)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements custom unmarshaling for ServerInfo
+func (si *ServerInfo) UnmarshalJSON(data []byte) error {
+	type Alias ServerInfo
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(si),
+	}
+
+	logInitialError := false
+	initialErr := json.Unmarshal(data, &aux)
+	errMsg := fmt.Sprintf("UnmarshalJSON error for ServerInfo: %v", initialErr)
+	dataMsg := fmt.Sprintf("Problematic JSON data for ServerInfo: %s", string(data))
+
+	if initialErr != nil {
+		log.Printf("Warning: Failed to unmarshal ServerInfo. Using reflective unmarshalling.")
+		if unmarshalErr := unmarshalReflectiveFields(data, si, "ServerInfo"); unmarshalErr != nil {
+			logInitialError = true
+		}
+	}
+
+	if logInitialError {
+		log.Println(errMsg)
+		log.Println(dataMsg)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements custom unmarshaling for UserInfo
+func (ui *UserInfo) UnmarshalJSON(data []byte) error {
+	type Alias UserInfo
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(ui),
+	}
+
+	logInitialError := false
+	initialErr := json.Unmarshal(data, &aux)
+	errMsg := fmt.Sprintf("UnmarshalJSON error for UserInfo: %v", initialErr)
+	dataMsg := fmt.Sprintf("Problematic JSON data for UserInfo: %s", string(data))
+
+	if initialErr != nil {
+		log.Printf("Warning: Failed to unmarshal UserInfo. Using reflective unmarshalling.")
+		if unmarshalErr := unmarshalReflectiveFields(data, ui, "UserInfo"); unmarshalErr != nil {
+			logInitialError = true
+		}
+	}
+
+	if logInitialError {
+		log.Println(errMsg)
+		log.Println(dataMsg)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements custom unmarshaling for AuthenticationResponse
+func (ar *AuthenticationResponse) UnmarshalJSON(data []byte) error {
+	type Alias AuthenticationResponse
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(ar),
+	}
+
+	logInitialError := false
+	initialErr := json.Unmarshal(data, &aux)
+	errMsg := fmt.Sprintf("UnmarshalJSON error for AuthenticationResponse: %v", initialErr)
+	dataMsg := fmt.Sprintf("Problematic JSON data for AuthenticationResponse: %s", string(data))
+
+	if initialErr != nil {
+		log.Printf("Warning: Failed to unmarshal AuthenticationResponse. Using reflective unmarshalling.")
+		if unmarshalErr := unmarshalReflectiveFields(data, ar, "AuthenticationResponse"); unmarshalErr != nil {
+			logInitialError = true
+		}
+	}
+
+	if logInitialError {
+		log.Println(errMsg)
+		log.Println(dataMsg)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements custom unmarshaling for Category
+func (c *Category) UnmarshalJSON(data []byte) error {
+	type Alias Category
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(c),
+	}
+
+	logInitialError := false
+	initialErr := json.Unmarshal(data, &aux)
+	errMsg := fmt.Sprintf("UnmarshalJSON error for Category: %v", initialErr)
+	dataMsg := fmt.Sprintf("Problematic JSON data for Category: %s", string(data))
+
+	if initialErr != nil {
+		log.Printf("Warning: Failed to unmarshal Category. Using reflective unmarshalling.")
+		if unmarshalErr := unmarshalReflectiveFields(data, c, "Category"); unmarshalErr != nil {
+			logInitialError = true
+		}
+	}
+
+	if logInitialError {
+		log.Println(errMsg)
+		log.Println(dataMsg)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements custom unmarshaling for Stream
+func (s *Stream) UnmarshalJSON(data []byte) error {
+	type Alias Stream
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(s),
+	}
+
+	logInitialError := false
+	initialErr := json.Unmarshal(data, &aux)
+	errMsg := fmt.Sprintf("UnmarshalJSON error for Stream: %v", initialErr)
+	dataMsg := fmt.Sprintf("Problematic JSON data for Stream: %s", string(data))
+
+	if initialErr != nil {
+		log.Printf("Warning: Failed to unmarshal Stream. Using reflective unmarshalling.")
+		if unmarshalErr := unmarshalReflectiveFields(data, s, "Stream"); unmarshalErr != nil {
+			logInitialError = true
+		}
+	}
+
+	if logInitialError {
+		log.Println(errMsg)
+		log.Println(dataMsg)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements custom unmarshaling for SeriesInfo
+func (si *SeriesInfo) UnmarshalJSON(data []byte) error {
+	type Alias SeriesInfo
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(si),
+	}
+
+	logInitialError := false
+	initialErr := json.Unmarshal(data, &aux)
+	errMsg := fmt.Sprintf("UnmarshalJSON error for SeriesInfo: %v", initialErr)
+	dataMsg := fmt.Sprintf("Problematic JSON data for SeriesInfo: %s", string(data))
+
+	if initialErr != nil {
+		log.Printf("Warning: Failed to unmarshal SeriesInfo. Using reflective unmarshalling.")
+		if unmarshalErr := unmarshalReflectiveFields(data, si, "SeriesInfo"); unmarshalErr != nil {
+			logInitialError = true
+		}
+	}
+
+	if logInitialError {
+		log.Println(errMsg)
+		log.Println(dataMsg)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements custom unmarshaling for Series
+func (s *Series) UnmarshalJSON(data []byte) error {
+	type Alias Series
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(s),
+	}
+
+	logInitialError := false
+	initialErr := json.Unmarshal(data, &aux)
+	errMsg := fmt.Sprintf("UnmarshalJSON error for Series: %v", initialErr)
+	dataMsg := fmt.Sprintf("Problematic JSON data for Series: %s", string(data))
+
+	if initialErr != nil {
+		log.Printf("Warning: Failed to unmarshal Series. Using reflective unmarshalling.")
+		if unmarshalErr := unmarshalReflectiveFields(data, s, "Series"); unmarshalErr != nil {
+			logInitialError = true
+		}
+	}
+
+	if logInitialError {
+		log.Println(errMsg)
+		log.Println(dataMsg)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements custom unmarshaling for EPGInfo
+func (ei *EPGInfo) UnmarshalJSON(data []byte) error {
+	type Alias EPGInfo
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(ei),
+	}
+
+	logInitialError := false
+	initialErr := json.Unmarshal(data, &aux)
+	errMsg := fmt.Sprintf("UnmarshalJSON error for EPGInfo: %v", initialErr)
+	dataMsg := fmt.Sprintf("Problematic JSON data for EPGInfo: %s", string(data))
+
+	if initialErr != nil {
+		log.Printf("Warning: Failed to unmarshal EPGInfo. Using reflective unmarshalling.")
+		if unmarshalErr := unmarshalReflectiveFields(data, ei, "EPGInfo"); unmarshalErr != nil {
+			logInitialError = true
+		}
+	}
+
+	if logInitialError {
+		log.Println(errMsg)
+		log.Println(dataMsg)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON implements custom unmarshaling for FFMPEGStreamInfo
+func (fsi *FFMPEGStreamInfo) UnmarshalJSON(data []byte) error {
+	type Alias FFMPEGStreamInfo
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(fsi),
+	}
+
+	logInitialError := false
+	initialErr := json.Unmarshal(data, &aux)
+	errMsg := fmt.Sprintf("UnmarshalJSON error for FFMPEGStreamInfo: %v", initialErr)
+	dataMsg := fmt.Sprintf("Problematic JSON data for FFMPEGStreamInfo: %s", string(data))
+
+	if initialErr != nil {
+		log.Printf("Warning: Failed to unmarshal FFMPEGStreamInfo. Using reflective unmarshalling.")
+		if unmarshalErr := unmarshalReflectiveFields(data, fsi, "FFMPEGStreamInfo"); unmarshalErr != nil {
+			logInitialError = true
+		}
+	}
+
+	if logInitialError {
 		log.Println(errMsg)
 		log.Println(dataMsg)
 	}

--- a/vendor/github.com/tellytv/go.xtream-codes/structs_test.go
+++ b/vendor/github.com/tellytv/go.xtream-codes/structs_test.go
@@ -1,0 +1,67 @@
+package xtreamcodes
+
+import (
+	"encoding/json"
+	"log"
+	"testing"
+)
+
+func TestAuthenticationResponseUnmarshal(t *testing.T) {
+	log.Printf("TestAuthenticationResponseUnmarshal: called")
+	jsonData := `{
+		"user_info": {
+			"username": "myxtreamuser",
+			"password": "myxtreampass",
+			"message": "Less is more..",
+			"auth": 1,
+			"status": "Active",
+			"exp_date": "1733423929",
+			"is_trial": "0",
+			"active_cons": 0,
+			"created_at": "1725565129",
+			"max_connections": "4",
+			"allowed_output_formats": [
+				"m3u8",
+				"ts"
+			]
+		},
+		"server_info": {
+			"url": "provider.com",
+			"port": "80",
+			"https_port": "443",
+			"server_protocol": "https",
+			"rtmp_port": "30002",
+			"timezone": "Pacific/Easter",
+			"timestamp_now": 1729207595,
+			"time_now": "2024-10-17 18:26:35",
+			"process": true
+		}
+	}`
+
+	var authResponse AuthenticationResponse
+	err := json.Unmarshal([]byte(jsonData), &authResponse)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal AuthenticationResponse: %v", err)
+	}
+
+	// Pretty print the entire AuthenticationResponse
+	prettyJSON, err := json.MarshalIndent(authResponse, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal AuthenticationResponse to pretty JSON: %v", err)
+	}
+	log.Printf("AuthenticationResponse:\n%s", string(prettyJSON))
+
+	// Pretty print UserInfo
+	prettyUserInfo, err := json.MarshalIndent(authResponse.UserInfo, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal UserInfo to pretty JSON: %v", err)
+	}
+	log.Printf("UserInfo:\n%s", string(prettyUserInfo))
+
+	// Pretty print ServerInfo
+	prettyServerInfo, err := json.MarshalIndent(authResponse.ServerInfo, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal ServerInfo to pretty JSON: %v", err)
+	}
+	log.Printf("ServerInfo:\n%s", string(prettyServerInfo))
+}

--- a/vendor/github.com/tellytv/go.xtream-codes/xtream-codes.go
+++ b/vendor/github.com/tellytv/go.xtream-codes/xtream-codes.go
@@ -306,6 +306,7 @@ func (c *XtreamClient) sendRequest(action string, parameters url.Values) ([]byte
 	file := "player_api.php"
 	if action == "xmltv.php" {
 		file = action
+		action = ""
 	}
 	url := fmt.Sprintf("%s/%s?username=%s&password=%s", c.BaseURL, file, c.Username, c.Password)
 	if action != "" {


### PR DESCRIPTION
This update fixes the incorrectly routed XMLTV links for EPG data and addresses an issue with Xtream Codes VOD (Shows & Movies), where the IPTV provider returned incomplete or missing data that the proxy expected.

Thanks to @jtdevops for the fix!

See issue #155 for more details.